### PR TITLE
Add CLI and dark-themed GUI for YBS Print Calander

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,53 @@
+# YBS Print Calander
 
+The YBS Print Calander project provides both a command-line interface (CLI) and a
+Tkinter GUI for logging into the YBS portal, confirming the login status, and
+retrieving the latest order information. Orders are displayed in a two-column
+format showing the order number and the associated company name.
+
+## Features
+
+- **CLI** utility to authenticate and print a formatted order table.
+- **Dark blue themed Tkinter GUI** featuring username/password inputs, a
+  red/green status light for login feedback, and a live order table.
+- Scrapes order numbers and company names from the YBS manage page after a
+  successful login.
+
+## Requirements
+
+Install the dependencies before running the application:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the GUI
+
+Launch the GUI directly with:
+
+```bash
+python -m ybs_print_calander
+```
+
+The GUI allows you to enter a username and password, attempt a login, and view
+the retrieved orders in a centered two-column table. A yellow indicator shows an
+in-progress login, which turns green on success or red on failure.
+
+## Using the CLI
+
+Run the CLI tool to log in and print the order table:
+
+```bash
+python -m ybs_print_calander.cli --username YOUR_USERNAME --password YOUR_PASSWORD
+```
+
+If you omit either argument, the CLI will prompt interactively. Use
+`--no-prompt` to force non-interactive behaviour (in which case both credentials
+must be supplied on the command line).
+
+## Notes
+
+- A working internet connection and valid YBS portal credentials are required
+  for successful login and order retrieval.
+- The project does not store credentials. They are only used for the active
+  session with the remote service.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+beautifulsoup4

--- a/ybs_print_calander/__init__.py
+++ b/ybs_print_calander/__init__.py
@@ -1,0 +1,7 @@
+"""Core package for the YBS Print Calander application."""
+
+__all__ = [
+    "client",
+    "cli",
+    "gui",
+]

--- a/ybs_print_calander/__main__.py
+++ b/ybs_print_calander/__main__.py
@@ -1,0 +1,11 @@
+"""Entry point for running the GUI via ``python -m ybs_print_calander``."""
+
+from .gui import launch_app
+
+
+def main() -> None:
+    launch_app()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual usage
+    main()

--- a/ybs_print_calander/cli.py
+++ b/ybs_print_calander/cli.py
@@ -1,0 +1,99 @@
+"""Command line interface for the YBS Print Calander."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from getpass import getpass
+from typing import Iterable, Sequence
+
+from .client import AuthenticationError, NetworkError, OrderRecord, YBSClient
+
+
+def _prompt_for_missing(value: str | None, prompt: str, secret: bool = False) -> str:
+    if value:
+        return value
+    if secret:
+        return getpass(prompt)
+    return input(prompt)
+
+
+def _format_table(orders: Sequence[OrderRecord]) -> str:
+    headers = ("Order#", "Company")
+    column_widths = [len(header) for header in headers]
+
+    for order in orders:
+        column_widths[0] = max(column_widths[0], len(order.order_number))
+        column_widths[1] = max(column_widths[1], len(order.company))
+
+    divider = "+".join("-" * (width + 2) for width in column_widths)
+    divider = f"+{divider}+"
+
+    header_line = "|".join(
+        f" {header.center(width)} " for header, width in zip(headers, column_widths)
+    )
+    header_line = f"|{header_line}|"
+
+    lines = [divider, header_line, divider]
+
+    for order in orders:
+        row_line = "|".join(
+            (
+                f" {order.order_number.center(column_widths[0])} ",
+                f" {order.company.center(column_widths[1])} ",
+            )
+        )
+        lines.append(f"|{row_line}|")
+
+    lines.append(divider)
+    return "\n".join(lines)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="YBS Print Calander CLI")
+    parser.add_argument("--username", "-u", help="Username used for the YBS portal")
+    parser.add_argument("--password", "-p", help="Password used for the YBS portal")
+    parser.add_argument(
+        "--no-prompt",
+        action="store_true",
+        help="Fail immediately if credentials are not supplied via arguments",
+    )
+
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if args.no_prompt and (args.username is None or args.password is None):
+        parser.error("--no-prompt requires both --username and --password to be provided")
+
+    username = _prompt_for_missing(args.username, "Username: ")
+    password = _prompt_for_missing(args.password, "Password: ", secret=True)
+
+    client = YBSClient()
+
+    try:
+        client.login(username, password)
+    except AuthenticationError as exc:
+        print(f"Login failed: {exc}", file=sys.stderr)
+        return 1
+    except NetworkError as exc:
+        print(f"Network error: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        orders = client.fetch_orders()
+    except AuthenticationError as exc:
+        print(f"Unable to retrieve orders: {exc}", file=sys.stderr)
+        return 1
+    except NetworkError as exc:
+        print(f"Network error while fetching orders: {exc}", file=sys.stderr)
+        return 2
+
+    if not orders:
+        print("No orders were returned from the manage page.")
+        return 0
+
+    print(_format_table(orders))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual usage
+    raise SystemExit(main())

--- a/ybs_print_calander/client.py
+++ b/ybs_print_calander/client.py
@@ -1,0 +1,128 @@
+"""Networking client for the YBS Print Calander application."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Iterable, List, Optional
+
+import requests
+from bs4 import BeautifulSoup, Tag
+
+
+class YBSError(Exception):
+    """Base exception for YBS related errors."""
+
+
+class AuthenticationError(YBSError):
+    """Raised when authentication with the YBS portal fails."""
+
+
+class NetworkError(YBSError):
+    """Raised when the remote service cannot be reached."""
+
+
+@dataclass
+class OrderRecord:
+    """Represents a single order entry scraped from the manage page."""
+
+    order_number: str
+    company: str
+
+
+class YBSClient:
+    """Simple HTTP client responsible for logging in and scraping orders."""
+
+    LOGIN_URL = "https://www.ybsnow.com/index.php"
+    MANAGE_URL = "https://www.ybsnow.com/manage.html"
+
+    def __init__(self, session: Optional[requests.Session] = None) -> None:
+        self.session = session or requests.Session()
+        self.session.headers.setdefault(
+            "User-Agent",
+            "YBS Print Calander/1.0 (+https://www.ybsnow.com/)",
+        )
+
+    def login(self, username: str, password: str) -> bool:
+        """Attempt to authenticate with the YBS website.
+
+        Args:
+            username: The username or email address used to sign in.
+            password: The account password.
+
+        Returns:
+            ``True`` if the login appears to be successful.
+
+        Raises:
+            AuthenticationError: If the credentials are rejected by the server.
+            NetworkError: If the network request cannot be completed.
+        """
+
+        payload = {
+            "email": username,
+            "password": password,
+            "action": "signin",
+        }
+
+        try:
+            response = self.session.post(self.LOGIN_URL, data=payload, timeout=10)
+            response.raise_for_status()
+        except requests.RequestException as exc:  # pragma: no cover - defensive
+            raise NetworkError("Failed to reach the YBS login page.") from exc
+
+        # Verify authentication by attempting to load the manage page.
+        try:
+            manage_response = self.session.get(self.MANAGE_URL, timeout=10)
+            manage_response.raise_for_status()
+        except requests.RequestException as exc:  # pragma: no cover - defensive
+            raise NetworkError("Failed to verify login with the manage page.") from exc
+
+        if self._is_login_page(manage_response.text):
+            raise AuthenticationError("Login failed. Please verify your username and password.")
+
+        return True
+
+    def fetch_orders(self) -> List[OrderRecord]:
+        """Fetch and parse the orders from the manage page."""
+
+        try:
+            response = self.session.get(self.MANAGE_URL, timeout=10)
+            response.raise_for_status()
+        except requests.RequestException as exc:  # pragma: no cover - defensive
+            raise NetworkError("Failed to retrieve the orders page.") from exc
+
+        if self._is_login_page(response.text):
+            raise AuthenticationError("Cannot fetch orders without logging in first.")
+
+        return list(self._parse_orders(response.text))
+
+    def _is_login_page(self, html: str) -> bool:
+        lowered = html.lower()
+        return "id=\"signin\"" in lowered or "name=\"signin\"" in lowered
+
+    def _parse_orders(self, html: str) -> Iterable[OrderRecord]:
+        soup = BeautifulSoup(html, "html.parser")
+
+        for row in soup.find_all("tr"):
+            move_cell = row.find("td", class_="move")
+            details_cell = row.find("td", class_=re.compile(r"\bdetails\b"))
+            if move_cell is None or details_cell is None:
+                continue
+
+            order_number = self._extract_order_number(move_cell.get_text(" ", strip=True))
+            company = self._extract_company(details_cell)
+
+            if order_number and company:
+                yield OrderRecord(order_number=order_number, company=company)
+
+    def _extract_order_number(self, text: str) -> Optional[str]:
+        match = re.search(r"\b(\d+)\b", text)
+        if match:
+            return match.group(1)
+        return None
+
+    def _extract_company(self, cell: Tag) -> Optional[str]:
+        first_paragraph = cell.find("p")
+        if first_paragraph:
+            return first_paragraph.get_text(strip=True)
+        return cell.get_text(strip=True) or None

--- a/ybs_print_calander/gui.py
+++ b/ybs_print_calander/gui.py
@@ -1,0 +1,237 @@
+"""Tkinter GUI for the YBS Print Calander application."""
+
+from __future__ import annotations
+
+import queue
+import threading
+import tkinter as tk
+from tkinter import ttk
+from typing import Iterable, List
+
+from .client import AuthenticationError, NetworkError, OrderRecord, YBSClient
+
+BACKGROUND_COLOR = "#0b1d3a"
+ACCENT_COLOR = "#1f3a63"
+TEXT_COLOR = "#f8f9fa"
+SUCCESS_COLOR = "#28a745"
+FAIL_COLOR = "#dc3545"
+PENDING_COLOR = "#f0ad4e"
+
+
+class YBSApp:
+    """Encapsulates the Tkinter application."""
+
+    def __init__(self, root: tk.Tk) -> None:
+        self.root = root
+        self.root.title("YBS Print Calander")
+        self.root.configure(background=BACKGROUND_COLOR)
+        self.root.geometry("720x480")
+
+        self.client = YBSClient()
+        self._queue: "queue.Queue[tuple[str, object]]" = queue.Queue()
+
+        self.username_var = tk.StringVar()
+        self.password_var = tk.StringVar()
+
+        self._configure_style()
+        self._build_layout()
+        self._poll_queue()
+
+    def _configure_style(self) -> None:
+        style = ttk.Style()
+        try:
+            style.theme_use("clam")
+        except tk.TclError:  # pragma: no cover - fallback path
+            pass
+
+        style.configure("Dark.TFrame", background=BACKGROUND_COLOR)
+        style.configure("Dark.TLabel", background=BACKGROUND_COLOR, foreground=TEXT_COLOR)
+        style.configure(
+            "Dark.TLabelframe",
+            background=BACKGROUND_COLOR,
+            foreground=TEXT_COLOR,
+            bordercolor=ACCENT_COLOR,
+            borderwidth=1,
+        )
+        style.configure(
+            "Dark.TLabelframe.Label",
+            background=BACKGROUND_COLOR,
+            foreground=TEXT_COLOR,
+        )
+        style.configure(
+            "Dark.TButton",
+            background=ACCENT_COLOR,
+            foreground=TEXT_COLOR,
+            borderwidth=0,
+            focusthickness=3,
+            focuscolor=ACCENT_COLOR,
+            padding=6,
+        )
+        style.map("Dark.TButton", background=[("active", "#25497a")])
+
+        style.configure(
+            "Dark.Treeview",
+            background="#102a54",
+            foreground=TEXT_COLOR,
+            fieldbackground="#102a54",
+            bordercolor=ACCENT_COLOR,
+            borderwidth=1,
+            rowheight=26,
+        )
+        style.map("Dark.Treeview", background=[("selected", "#1e90ff")])
+        style.configure(
+            "Dark.Treeview.Heading",
+            background=ACCENT_COLOR,
+            foreground=TEXT_COLOR,
+            bordercolor=ACCENT_COLOR,
+            relief="flat",
+            padding=6,
+        )
+        style.map("Dark.Treeview.Heading", background=[("active", "#25497a")])
+
+    def _build_layout(self) -> None:
+        container = ttk.Frame(self.root, style="Dark.TFrame")
+        container.pack(fill=tk.BOTH, expand=True, padx=20, pady=20)
+
+        login_frame = ttk.Frame(container, style="Dark.TFrame")
+        login_frame.pack(fill=tk.X, pady=(0, 20))
+
+        username_label = ttk.Label(login_frame, text="Username", style="Dark.TLabel")
+        username_label.grid(row=0, column=0, sticky=tk.W, padx=(0, 10))
+        username_entry = ttk.Entry(login_frame, textvariable=self.username_var, width=30)
+        username_entry.grid(row=0, column=1, sticky=tk.W)
+        username_entry.focus_set()
+
+        password_label = ttk.Label(login_frame, text="Password", style="Dark.TLabel")
+        password_label.grid(row=1, column=0, sticky=tk.W, padx=(0, 10), pady=(10, 0))
+        password_entry = ttk.Entry(login_frame, textvariable=self.password_var, show="*", width=30)
+        password_entry.grid(row=1, column=1, sticky=tk.W, pady=(10, 0))
+        username_entry.bind("<Return>", self._on_enter_pressed)
+        password_entry.bind("<Return>", self._on_enter_pressed)
+
+        button_frame = ttk.Frame(login_frame, style="Dark.TFrame")
+        button_frame.grid(row=0, column=2, rowspan=2, padx=(20, 0), sticky=tk.N)
+
+        self.status_canvas = tk.Canvas(
+            button_frame,
+            width=20,
+            height=20,
+            highlightthickness=0,
+            bg=BACKGROUND_COLOR,
+            bd=0,
+        )
+        self.status_canvas.pack(pady=(0, 8))
+        self.status_light = self.status_canvas.create_oval(2, 2, 18, 18, fill="#555555", outline="")
+
+        self.login_button = ttk.Button(
+            button_frame,
+            text="Login",
+            style="Dark.TButton",
+            command=self._on_login_clicked,
+        )
+        self.login_button.pack()
+
+        self.status_message = ttk.Label(login_frame, text="", style="Dark.TLabel")
+        self.status_message.grid(row=2, column=0, columnspan=3, sticky=tk.W, pady=(10, 0))
+
+        table_frame = ttk.LabelFrame(
+            container,
+            text="Orders",
+            style="Dark.TLabelframe",
+            padding=10,
+        )
+        table_frame.configure(labelanchor="n")
+        table_frame.pack(fill=tk.BOTH, expand=True)
+
+        # Treeview and scrollbar
+        self.tree = ttk.Treeview(
+            table_frame,
+            columns=("order", "company"),
+            show="headings",
+            style="Dark.Treeview",
+        )
+        self.tree.heading("order", text="Order#", anchor="center")
+        self.tree.heading("company", text="Company", anchor="center")
+        self.tree.column("order", anchor="center", width=120, stretch=False)
+        self.tree.column("company", anchor="center", width=400)
+
+        scrollbar = ttk.Scrollbar(table_frame, orient="vertical", command=self.tree.yview)
+        self.tree.configure(yscrollcommand=scrollbar.set)
+
+        self.tree.grid(row=0, column=0, sticky="nsew")
+        scrollbar.grid(row=0, column=1, sticky="ns")
+
+        table_frame.columnconfigure(0, weight=1)
+        table_frame.rowconfigure(0, weight=1)
+
+    def _on_login_clicked(self) -> None:
+        username = self.username_var.get().strip()
+        password = self.password_var.get()
+
+        if not username or not password:
+            self._set_status(FAIL_COLOR, "Please enter both a username and password.")
+            return
+
+        self.login_button.config(state=tk.DISABLED)
+        self._set_status(PENDING_COLOR, "Attempting login...")
+
+        thread = threading.Thread(
+            target=self._perform_login,
+            args=(username, password),
+            daemon=True,
+        )
+        thread.start()
+
+    def _on_enter_pressed(self, event: object | None) -> None:
+        self._on_login_clicked()
+
+    def _set_status(self, color: str, message: str) -> None:
+        self.status_canvas.itemconfigure(self.status_light, fill=color)
+        self.status_message.config(text=message)
+
+    def _perform_login(self, username: str, password: str) -> None:
+        try:
+            self.client.login(username, password)
+            orders = self.client.fetch_orders()
+        except (AuthenticationError, NetworkError) as exc:
+            self._queue.put(("login_result", False, str(exc), []))
+        except Exception as exc:  # pragma: no cover - defensive
+            self._queue.put(("login_result", False, f"Unexpected error: {exc}", []))
+        else:
+            self._queue.put(("login_result", True, "Login successful.", orders))
+
+    def _poll_queue(self) -> None:
+        try:
+            while True:
+                event_type, success, message, payload = self._queue.get_nowait()
+                if event_type == "login_result":
+                    self._handle_login_result(bool(success), str(message), list(payload))
+        except queue.Empty:
+            pass
+        finally:
+            self.root.after(100, self._poll_queue)
+
+    def _handle_login_result(self, success: bool, message: str, orders: List[OrderRecord]) -> None:
+        color = SUCCESS_COLOR if success else FAIL_COLOR
+        self._set_status(color, message)
+        self.login_button.config(state=tk.NORMAL)
+        if success:
+            self._populate_orders(orders)
+            if not orders:
+                self.status_message.config(text="Login successful, but no orders were found.")
+
+    def _populate_orders(self, orders: Iterable[OrderRecord]) -> None:
+        for item in self.tree.get_children():
+            self.tree.delete(item)
+        for order in orders:
+            self.tree.insert("", tk.END, values=(order.order_number, order.company))
+
+
+def launch_app() -> None:
+    root = tk.Tk()
+    app = YBSApp(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual usage
+    launch_app()


### PR DESCRIPTION
## Summary
- add a requests-based client that authenticates with the YBS portal and scrapes orders
- provide a CLI wrapper for logging in and displaying the orders table from the terminal
- build a dark blue themed Tkinter GUI with login status indicator and centered order table
- document usage instructions and required dependencies

## Testing
- python -m compileall ybs_print_calander
- python -m ybs_print_calander.cli --help


------
https://chatgpt.com/codex/tasks/task_e_68cb5fc9be6c832da881aad1c6060c4d