### PR TITLE
Add drag-and-drop support for calendar assignments

### DIFF
--- a/ybs_print_calander/gui.py
+++ b/ybs_print_calander/gui.py
@@ -8,7 +8,7 @@ import queue
 import threading
 import tkinter as tk
 from tkinter import ttk
-from typing import Iterable, List
+from typing import Dict, Iterable, List, Tuple
 
 from .client import AuthenticationError, NetworkError, OrderRecord, YBSClient
 
@@ -18,6 +18,8 @@ TEXT_COLOR = "#f8f9fa"
 SUCCESS_COLOR = "#28a745"
 FAIL_COLOR = "#dc3545"
 PENDING_COLOR = "#f0ad4e"
+
+DRAG_THRESHOLD = 5
 
 
 class YBSApp:
@@ -31,6 +33,13 @@ class YBSApp:
 
         self.client = YBSClient()
         self._queue: "queue.Queue[tuple[str, object]]" = queue.Queue()
+
+        self._calendar_cells: Dict[int, Tuple[str, str]] = {}
+        self._calendar_cell_lookup: Dict[Tuple[str, str], int] = {}
+        self._calendar_assignments: Dict[int, List[Tuple[str, str]]] = {}
+        self._calendar_hover: tuple[str, str] | None = None
+        self._drag_data: dict[str, object] = {}
+        self._reset_drag_state()
 
         self.username_var = tk.StringVar()
         self.password_var = tk.StringVar()
@@ -166,6 +175,10 @@ class YBSApp:
         self.tree.grid(row=0, column=0, sticky="nsew")
         scrollbar.grid(row=0, column=1, sticky="ns")
 
+        self.tree.bind("<ButtonPress-1>", self._on_order_press)
+        self.tree.bind("<B1-Motion>", self._on_order_drag)
+        self.tree.bind("<ButtonRelease-1>", self._on_order_release)
+
         table_frame.columnconfigure(0, weight=1)
         table_frame.rowconfigure(0, weight=1)
 
@@ -194,15 +207,29 @@ class YBSApp:
             selectmode="none",
         )
 
+        self.calendar_tree.tag_configure("hover_valid", background="#25497a")
+        self.calendar_tree.tag_configure("hover_invalid", background="#5a1f1f")
+
         for index, day_name in enumerate(calendar.day_abbr):
             column_id = columns[index]
             self.calendar_tree.heading(column_id, text=day_name, anchor="center")
             self.calendar_tree.column(column_id, anchor="center", width=50, stretch=True)
 
         month_structure = calendar.Calendar().monthdayscalendar(today.year, today.month)
+        self._calendar_cells.clear()
+        self._calendar_cell_lookup.clear()
+        self._calendar_assignments.clear()
+        self._calendar_hover = None
+
         for week in month_structure:
-            formatted_week = [day if day != 0 else "" for day in week]
-            self.calendar_tree.insert("", tk.END, values=formatted_week)
+            formatted_week = [str(day) if day != 0 else "" for day in week]
+            item_id = self.calendar_tree.insert("", tk.END, values=formatted_week)
+            for index, day in enumerate(week):
+                if day == 0:
+                    continue
+                column_name = columns[index]
+                self._calendar_cells[day] = (item_id, column_name)
+                self._calendar_cell_lookup[(item_id, column_name)] = day
 
         self.calendar_tree.state(["disabled"])
         self.calendar_tree.grid(row=1, column=0, sticky="nsew")
@@ -211,6 +238,284 @@ class YBSApp:
         calendar_frame.rowconfigure(1, weight=1)
 
         content_paned.add(calendar_frame, weight=2)
+
+    def _reset_drag_state(self) -> None:
+        self._drag_data = {
+            "item": None,
+            "values": (),
+            "start_x": 0,
+            "start_y": 0,
+            "widget": None,
+            "active": False,
+        }
+
+    def _on_order_press(self, event: tk.Event) -> None:
+        self._end_drag()
+        item_id = self.tree.identify_row(event.y)
+        if not item_id:
+            self.tree.selection_remove(self.tree.selection())
+            return
+
+        self.tree.selection_set(item_id)
+        values = self.tree.item(item_id, "values") or ()
+        if not isinstance(values, tuple):
+            values = tuple(values)
+
+        self._drag_data.update(
+            {
+                "item": item_id,
+                "values": values,
+                "start_x": event.x_root,
+                "start_y": event.y_root,
+                "widget": None,
+                "active": False,
+            }
+        )
+
+    def _on_order_drag(self, event: tk.Event) -> None:
+        item_id = self._drag_data.get("item")
+        if not item_id:
+            return
+
+        if not self._drag_data.get("active"):
+            start_x = int(self._drag_data.get("start_x", event.x_root))
+            start_y = int(self._drag_data.get("start_y", event.y_root))
+            if (
+                abs(event.x_root - start_x) >= DRAG_THRESHOLD
+                or abs(event.y_root - start_y) >= DRAG_THRESHOLD
+            ):
+                self._begin_drag()
+
+        if not self._drag_data.get("active"):
+            return
+
+        self._position_drag_window(event.x_root, event.y_root)
+        target_info = self._detect_calendar_target(event.x_root, event.y_root)
+        self._update_calendar_hover(target_info)
+
+    def _on_order_release(self, event: tk.Event) -> None:
+        item_id = self._drag_data.get("item")
+        if not item_id:
+            return
+
+        if not self._drag_data.get("active"):
+            self._end_drag()
+            return
+
+        target_info = self._detect_calendar_target(event.x_root, event.y_root)
+        if target_info and target_info.get("day") is not None:
+            day_value = int(target_info["day"])
+            values = self._drag_data.get("values", ())
+            if not isinstance(values, (tuple, list)) or not values:
+                self._queue.put(
+                    (
+                        "calendar_drop",
+                        False,
+                        "Unable to determine which order was dragged.",
+                        None,
+                    )
+                )
+            else:
+                order_values = tuple(str(value) for value in values)
+                order_number = order_values[0]
+                company = order_values[1] if len(order_values) > 1 else ""
+                message = f"Assigned order {order_number}"
+                if company:
+                    message += f" ({company})"
+                message += f" to day {day_value}."
+                self._queue.put(
+                    (
+                        "calendar_drop",
+                        True,
+                        message,
+                        {"day": day_value, "values": order_values},
+                    )
+                )
+        else:
+            self._queue.put(
+                (
+                    "calendar_drop",
+                    False,
+                    "Please drop orders onto a valid calendar day.",
+                    None,
+                )
+            )
+
+        self._end_drag()
+
+    def _begin_drag(self) -> None:
+        item_id = self._drag_data.get("item")
+        values = self._drag_data.get("values", ())
+        if not item_id or not isinstance(values, (tuple, list)):
+            return
+
+        order_values = tuple(str(value) for value in values)
+        text_parts = [part for part in order_values if part]
+        label_text = " - ".join(text_parts) if text_parts else ""
+
+        drag_window = tk.Toplevel(self.root)
+        drag_window.overrideredirect(True)
+        try:  # pragma: no cover - platform dependent feature
+            drag_window.attributes("-topmost", True)
+        except tk.TclError:
+            pass
+        drag_window.configure(bg=ACCENT_COLOR)
+
+        label = tk.Label(
+            drag_window,
+            text=label_text,
+            bg=ACCENT_COLOR,
+            fg=TEXT_COLOR,
+            padx=8,
+            pady=4,
+            bd=0,
+        )
+        label.pack()
+
+        self._drag_data["widget"] = drag_window
+        self._drag_data["values"] = order_values
+        self._drag_data["active"] = True
+
+        start_x = int(self._drag_data.get("start_x", 0))
+        start_y = int(self._drag_data.get("start_y", 0))
+        self._position_drag_window(start_x, start_y)
+
+    def _position_drag_window(self, x_root: int, y_root: int) -> None:
+        widget = self._drag_data.get("widget")
+        if widget is None:
+            return
+        widget.geometry(f"+{x_root + 16}+{y_root + 16}")
+
+    def _detect_calendar_target(self, x_root: int, y_root: int) -> Dict[str, object] | None:
+        calendar_x = self.calendar_tree.winfo_rootx()
+        calendar_y = self.calendar_tree.winfo_rooty()
+        width = self.calendar_tree.winfo_width()
+        height = self.calendar_tree.winfo_height()
+
+        if not (
+            calendar_x <= x_root <= calendar_x + width
+            and calendar_y <= y_root <= calendar_y + height
+        ):
+            return None
+
+        relative_x = x_root - calendar_x
+        relative_y = y_root - calendar_y
+        row_id = self.calendar_tree.identify_row(relative_y)
+        column = self.calendar_tree.identify_column(relative_x)
+
+        if not row_id or not column:
+            return {"item": row_id, "column": column, "day": None}
+
+        try:
+            column_index = int(column.lstrip("#")) - 1
+        except ValueError:
+            return {"item": row_id, "column": column, "day": None}
+
+        columns = self.calendar_tree["columns"]
+        if column_index < 0 or column_index >= len(columns):
+            return {"item": row_id, "column": column, "day": None}
+
+        column_name = columns[column_index]
+        day_value = self._calendar_cell_lookup.get((row_id, column_name))
+        return {"item": row_id, "column": column_name, "day": day_value}
+
+    def _update_calendar_hover(self, target_info: Dict[str, object] | None) -> None:
+        if not target_info or not target_info.get("item"):
+            self._remove_calendar_hover()
+            return
+
+        item_id = str(target_info["item"])
+        day_value = target_info.get("day")
+        is_valid = day_value is not None
+        self._apply_calendar_hover(item_id, is_valid)
+
+    def _apply_calendar_hover(self, item_id: str, is_valid: bool) -> None:
+        tag_to_apply = "hover_valid" if is_valid else "hover_invalid"
+
+        if self._calendar_hover and self._calendar_hover[0] != item_id:
+            self._remove_calendar_hover()
+
+        if self._calendar_hover and self._calendar_hover == (item_id, tag_to_apply):
+            return
+
+        current_tags = set(self.calendar_tree.item(item_id, "tags") or ())
+        current_tags.discard("hover_valid")
+        current_tags.discard("hover_invalid")
+        current_tags.add(tag_to_apply)
+        self.calendar_tree.item(item_id, tags=tuple(current_tags))
+        self._calendar_hover = (item_id, tag_to_apply)
+
+    def _remove_calendar_hover(self) -> None:
+        if not self._calendar_hover:
+            return
+
+        item_id, tag_name = self._calendar_hover
+        current_tags = set(self.calendar_tree.item(item_id, "tags") or ())
+        if tag_name in current_tags:
+            current_tags.remove(tag_name)
+            self.calendar_tree.item(item_id, tags=tuple(current_tags))
+        self._calendar_hover = None
+
+    def _end_drag(self) -> None:
+        widget = self._drag_data.get("widget")
+        if widget is not None:
+            try:  # pragma: no cover - defensive cleanup
+                widget.destroy()
+            except tk.TclError:
+                pass
+        self._remove_calendar_hover()
+        self._reset_drag_state()
+
+    def _handle_calendar_drop(self, success: bool, message: str, payload: object | None) -> None:
+        color = SUCCESS_COLOR if success else FAIL_COLOR
+        self._set_status(color, message)
+        if not success:
+            return
+
+        if not isinstance(payload, dict):
+            return
+
+        day_value = payload.get("day")
+        values = payload.get("values")
+        if not isinstance(day_value, int) or not isinstance(values, (tuple, list)):
+            return
+
+        order_values = tuple(str(value) for value in values)
+        self._assign_order_to_day(day_value, order_values)
+
+    def _assign_order_to_day(self, day: int, order_values: Tuple[str, ...]) -> None:
+        target = self._calendar_cells.get(day)
+        if not target:
+            return
+
+        item_id, column_name = target
+        order_number = order_values[0] if len(order_values) > 0 else ""
+        company = order_values[1] if len(order_values) > 1 else ""
+        normalized: Tuple[str, str] = (str(order_number), str(company))
+
+        assignments = self._calendar_assignments.setdefault(day, [])
+        if normalized not in assignments:
+            assignments.append(normalized)
+
+        display_text = self._format_day_cell(day, assignments)
+        self.calendar_tree.set(item_id, column_name, display_text)
+
+    def _format_day_cell(self, day: int, assignments: List[Tuple[str, str]]) -> str:
+        if not assignments:
+            return str(day)
+
+        labels: List[str] = []
+        for order_number, company in assignments:
+            label = order_number.strip()
+            if not label and company:
+                label = company.strip()
+            if label:
+                labels.append(label)
+
+        if not labels:
+            return str(day)
+
+        return f"{day} ({', '.join(labels)})"
 
     def _on_login_clicked(self) -> None:
         username = self.username_var.get().strip()
@@ -254,6 +559,8 @@ class YBSApp:
                 event_type, success, message, payload = self._queue.get_nowait()
                 if event_type == "login_result":
                     self._handle_login_result(bool(success), str(message), list(payload))
+                elif event_type == "calendar_drop":
+                    self._handle_calendar_drop(bool(success), str(message), payload)
         except queue.Empty:
             pass
         finally:


### PR DESCRIPTION
## Summary
- add drag event bindings to the orders tree and track drag state for the UI thread
- handle drop events through the existing queue to update calendar cells and status feedback
- highlight calendar targets, reject invalid drops, and reflect assigned orders on the calendar

## Testing
- python -m compileall ybs_print_calander

------
https://chatgpt.com/codex/tasks/task_e_68cb63d264a0832d94873f7ce11e6495