### PR TITLE
Preserve multi-selection when dragging calendar orders

### DIFF
--- a/ybs_print_calander/gui.py
+++ b/ybs_print_calander/gui.py
@@ -1758,15 +1758,15 @@ class YBSApp:
                 orders_list.selection_set(index)
                 orders_list.selection_anchor(index)
         else:
-            orders_list.selection_clear(0, tk.END)
-            orders_list.selection_set(index)
+            if not orders_list.selection_includes(index):
+                orders_list.selection_clear(0, tk.END)
+                orders_list.selection_set(index)
             orders_list.selection_anchor(index)
 
         orders_list.activate(index)
 
-        selected_indices: tuple[int, ...] = tuple(
-            int(i) for i in orders_list.curselection()
-        )
+        current_selection = orders_list.curselection()
+        selected_indices: tuple[int, ...] = tuple(int(i) for i in current_selection)
 
         normalized_assignments: list[Tuple[str, str]] = []
         for idx in selected_indices:


### PR DESCRIPTION
## Summary
- avoid clearing calendar selections when clicking an already selected order so drag keeps every highlighted item
- derive drag metadata from the listbox's current selection to include all chosen assignments

## Testing
- python -m compileall ybs_print_calander

------
https://chatgpt.com/codex/tasks/task_e_68ce30fcda94832da7e7166e65aefdf7