### PR TITLE
Ensure single clicks reset day order selection

### DIFF
--- a/ybs_print_calander/gui.py
+++ b/ybs_print_calander/gui.py
@@ -1758,9 +1758,8 @@ class YBSApp:
                 orders_list.selection_set(index)
                 orders_list.selection_anchor(index)
         else:
-            if not orders_list.selection_includes(index):
-                orders_list.selection_clear(0, tk.END)
-                orders_list.selection_set(index)
+            orders_list.selection_clear(0, tk.END)
+            orders_list.selection_set(index)
             orders_list.selection_anchor(index)
 
         orders_list.activate(index)


### PR DESCRIPTION
## Summary
- ensure single-click selection in the calendar order list always resets to the clicked row without affecting modifier behavior

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ce330d28b0832da0d7a16ac1fdbf32