### PR TITLE
Preserve multi-selection when dragging orders

### DIFF
--- a/ybs_print_calander/gui.py
+++ b/ybs_print_calander/gui.py
@@ -1738,6 +1738,7 @@ class YBSApp:
 
         children = list(self.tree.get_children(""))
         anchor = self._normalize_tree_anchor(children)
+        current_selection = set(self.tree.selection())
 
         if shift_pressed and children:
             if anchor is None:
@@ -1759,7 +1760,6 @@ class YBSApp:
                 pass
             self._tree_selection_anchor = anchor
         elif ctrl_pressed:
-            current_selection = set(self.tree.selection())
             if item_id in current_selection:
                 try:
                     self.tree.selection_remove(item_id)
@@ -1776,11 +1776,14 @@ class YBSApp:
                 if anchor is None:
                     self._tree_selection_anchor = item_id
         else:
-            try:
-                self.tree.selection_set((item_id,))
-            except tk.TclError:
-                pass
-            self._tree_selection_anchor = item_id
+            if item_id in current_selection and current_selection:
+                self._tree_selection_anchor = item_id
+            else:
+                try:
+                    self.tree.selection_set((item_id,))
+                except tk.TclError:
+                    pass
+                self._tree_selection_anchor = item_id
 
         try:
             self.tree.focus(item_id)


### PR DESCRIPTION
## Summary
- stop clearing the tree selection when starting a drag on an already selected order
- keep the selection anchor in sync so existing multi-selection behavior remains consistent

## Testing
- python -m compileall ybs_print_calander

------
https://chatgpt.com/codex/tasks/task_e_68ce4e7e2a6c832da46b8f08ba5897b8