### PR TITLE
Fix multi-selection clearing in orders view

### DIFF
--- a/ybs_print_calander/gui.py
+++ b/ybs_print_calander/gui.py
@@ -2551,11 +2551,16 @@ class YBSApp:
             if drag_was_active:
                 self._end_drag()
                 return "break"
-            return None
+            self._end_drag()
+            # Prevent the default Treeview handler from overriding the
+            # selection we maintain manually when no drag occurs.
+            return "break"
 
         if not drag_was_active:
             self._end_drag()
-            return None
+            # Swallow the event so Tk does not collapse the selection when the
+            # user releases modifier keys after a click.
+            return "break"
 
         target_info = self._detect_calendar_target(event.x_root, event.y_root)
         normalized_key: DateKey | None = None


### PR DESCRIPTION
## Summary
- prevent the orders Treeview from losing its multi-selection when modifier keys are released by stopping the default release handler
- document why the custom release handler always swallows events when no drag occurs

## Testing
- python -m compileall ybs_print_calander

------
https://chatgpt.com/codex/tasks/task_e_68cf190b2a50832d943237d6a3d5488e