### PR TITLE
Prevent order selection from clearing when releasing modifiers

### DIFF
--- a/ybs_print_calander/gui.py
+++ b/ybs_print_calander/gui.py
@@ -2555,7 +2555,7 @@ class YBSApp:
 
         if not drag_was_active:
             self._end_drag()
-            return None
+            return "break"
 
         target_info = self._detect_calendar_target(event.x_root, event.y_root)
         normalized_key: DateKey | None = None


### PR DESCRIPTION
## Summary
- stop the tree view's default button-release handler from overwriting our custom multi-selection logic by always consuming the event when no drag occurred

## Testing
- python -m compileall ybs_print_calander

------
https://chatgpt.com/codex/tasks/task_e_68cf1e27c35c832dafe992ee2022b808