### PR TITLE
Preserve order selections during drag operations

### DIFF
--- a/ybs_print_calander/gui.py
+++ b/ybs_print_calander/gui.py
@@ -1163,11 +1163,17 @@ class YBSApp:
         self.tree.column("company", anchor="center", width=400)
 
         scrollbar = ttk.Scrollbar(table_frame, orient="vertical", command=self.tree.yview)
-        self.tree.configure(
-            yscrollcommand=scrollbar.set,
-            exportselection=False,
-            selectmode=tk.EXTENDED,
-        )
+        self.tree.configure(yscrollcommand=scrollbar.set)
+        # Guard Treeview configuration so builds that omit these options still
+        # run while retaining the improved behaviour where available.
+        try:
+            self.tree.configure(exportselection=False)
+        except tk.TclError:
+            pass
+        try:
+            self.tree.configure(selectmode="extended")
+        except tk.TclError:
+            pass
 
         self.tree.grid(row=2, column=0, sticky="nsew")
         scrollbar.grid(row=2, column=1, sticky="ns")

--- a/ybs_print_calander/gui.py
+++ b/ybs_print_calander/gui.py
@@ -1163,7 +1163,11 @@ class YBSApp:
         self.tree.column("company", anchor="center", width=400)
 
         scrollbar = ttk.Scrollbar(table_frame, orient="vertical", command=self.tree.yview)
-        self.tree.configure(yscrollcommand=scrollbar.set)
+        self.tree.configure(
+            yscrollcommand=scrollbar.set,
+            exportselection=False,
+            selectmode=tk.EXTENDED,
+        )
 
         self.tree.grid(row=2, column=0, sticky="nsew")
         scrollbar.grid(row=2, column=1, sticky="ns")


### PR DESCRIPTION
## Summary
- prevent the orders treeview from exporting its selection so Tk does not clear multi-select highlights when focus shifts during a drag
- explicitly keep the treeview in extended select mode while configuring the scrollbar linkage

## Testing
- python -m compileall ybs_print_calander

------
https://chatgpt.com/codex/tasks/task_e_68cf60f4d2e0832d880956ed4f431d05