### PR TITLE
Ensure order release handler preserves multi-selection

### DIFF
--- a/ybs_print_calander/gui.py
+++ b/ybs_print_calander/gui.py
@@ -2711,7 +2711,8 @@ class YBSApp:
             if drag_was_active:
                 self._end_drag()
                 return "break"
-            return None
+            self._end_drag()
+            return "break"
 
         if not drag_was_active:
             if self._drag_data.get("pending_tree_toggle"):
@@ -2737,7 +2738,7 @@ class YBSApp:
                         self._tree_selection_anchor = None
                 self._drag_data["pending_tree_toggle"] = False
             self._end_drag()
-            return None
+            return "break"
 
         target_info = self._detect_calendar_target(event.x_root, event.y_root)
         normalized_key: DateKey | None = None


### PR DESCRIPTION
## Summary
- return "break" from the order release handler even when no drag occurred so Tk doesn't collapse custom selections
- always end the drag state on release before handing control back to Tk

## Testing
- python -m compileall ybs_print_calander

------
https://chatgpt.com/codex/tasks/task_e_68cf6ed14c04832d9034fa12fca35275