### PR TITLE
Enable extended selection in orders treeview

### DIFF
--- a/ybs_print_calander/gui.py
+++ b/ybs_print_calander/gui.py
@@ -1298,7 +1298,7 @@ class YBSApp:
             columns=("order", "company"),
             show="headings",
             style="Dark.Treeview",
-            selectmode="browse",
+            selectmode=tk.EXTENDED,
         )
         self.tree.heading("order", text="Order#", anchor="center")
         self.tree.heading("company", text="Company", anchor="center")


### PR DESCRIPTION
## Summary
- allow selecting multiple orders by switching the orders Treeview to `tk.EXTENDED`

## Testing
- not run (GUI change)


------
https://chatgpt.com/codex/tasks/task_e_68cf8a6871e0832d9ff2e722c1f3bf75