### PR TITLE
Handle Ctrl-aware tree navigation

### DIFF
--- a/ybs_print_calander/gui.py
+++ b/ybs_print_calander/gui.py
@@ -2493,12 +2493,15 @@ class YBSApp:
         new_index = max(0, min(new_index, len(children) - 1))
         target = children[new_index]
 
-        try:
-            self.tree.selection_set((target,))
-        except tk.TclError:
-            pass
+        ctrl_pressed = self._is_control_pressed(event)
 
-        self._tree_selection_anchor = target
+        if not ctrl_pressed:
+            try:
+                self.tree.selection_set((target,))
+            except tk.TclError:
+                pass
+
+            self._tree_selection_anchor = target
 
         try:
             self.tree.focus(target)


### PR DESCRIPTION
## Summary
- update tree keyboard navigation to respect the Control modifier
- keep selection/anchor updates for navigation without Control

## Testing
- python -m compileall ybs_print_calander

------
https://chatgpt.com/codex/tasks/task_e_68d21f5d1414832d9b8fb1cfc7c2e70b